### PR TITLE
Fix .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,11 +1,8 @@
-# Package stuff
 ^LICENSE\.md$
 ^CODE_OF_CONDUCT\.md$
 ^Meta$
 ^doc$
 ^data-raw$
-
-# git and continuous integration stuff
 \.git*
 ^\.travis\.yml$
 ^\.appveyor\.yml$
@@ -13,11 +10,7 @@
 ^codecov\.yml$
 ^\.lintr$
 ^\.github$
-
-# RStudio stuff
 ^.*\.Rproj$
 ^\.Rproj\.user$
-
-# CRAN stuff
 ^cran-comments\.md$
 ^NEWS\.md$


### PR DESCRIPTION
- according to "Writing R Extensions" (https://cran.r-project.org/doc/manuals/R-exts.html#Building-package-tarballs), the "[exclude] patterns should be Perl-like regular expressions ..., one per line" the in the file ".Rbuildignore"
- `remotes:::in_r_build_ignore()` checks if any submodule path is included in the ".Rbuildignore" -- any path matches positively against an empty line, and the submodule is excluded from being downloaded
--> remove empty lines and comments to avoid false positives