### PR TITLE
Fix url for gha badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [ ![R build status][1]][2] [ ![github release][5]][6] [![license][7]][8] [![codecov status][9]][10]
 <!-- badges: end -->
 
-[1]: https://github.com/DrylandEcology/rSW2utils/actions/workflows/check-standard.yml/badge.svg?branch=main
+[1]: https://github.com/DrylandEcology/rSW2utils/actions/workflows/check-standard.yaml/badge.svg?branch=main
 [2]: https://github.com/DrylandEcology/rSW2utils/actions
 [5]: https://img.shields.io/github/release/DrylandEcology/rSW2utils.svg?label=current+release
 [6]: https://github.com/DrylandEcology/rSW2utils/releases


### PR DESCRIPTION
- commit c6755f93e2e79100303c1be16b52412ed764f70f changed the name of the gha check but mistakenly didn't update the url in the readme